### PR TITLE
feat: local login without GitHub app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
+# Simple login for local development
+DEV_GITHUB_TOKEN=
+
+# Github OAuth
 GITHUB_ID=
 GITHUB_SECRET=
+
+# Next-Auth secret (not required for local development)
+SECRET=

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,7 +36,7 @@ export const Header = () => {
                 </li>
                 {status === "authenticated" && (
                   <li>
-                    <Link href="/stats">Stats</Link>
+                    <Link href={`/stats/${session.user.login}`}>Stats</Link>
                   </li>
                 )}
               </ul>
@@ -52,7 +52,7 @@ export const Header = () => {
               </li>
               {status === "authenticated" && (
                 <li>
-                  <Link href="/stats">Stats</Link>
+                  <Link href={`/stats/${session.user.login}`}>Stats</Link>
                 </li>
               )}
             </ul>
@@ -86,7 +86,7 @@ export const Header = () => {
                 </ul>
               </div>
             ) : (
-              <button onClick={() => signIn("github")} className="btn">
+              <button onClick={() => signIn()} className="btn">
                 Sign in
               </button>
             )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { MAIN_LOGIN_PROVIDER } from "@/pages/api/auth/[...nextauth]";
 import { signIn, signOut, useSession } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
@@ -81,12 +82,23 @@ export const Header = () => {
                     </a>
                   </li>
                   <li>
-                    <a onClick={() => signOut()}>Logout</a>
+                    <a
+                      onClick={() =>
+                        signOut({
+                          callbackUrl: "/",
+                        })
+                      }
+                    >
+                      Logout
+                    </a>
                   </li>
                 </ul>
               </div>
             ) : (
-              <button onClick={() => signIn()} className="btn">
+              <button
+                onClick={() => signIn(MAIN_LOGIN_PROVIDER)}
+                className="btn"
+              >
                 Sign in
               </button>
             )}

--- a/src/hooks/useGitHubPullRequests.ts
+++ b/src/hooks/useGitHubPullRequests.ts
@@ -3,12 +3,13 @@ import { useGitHubQuery } from "./useGitHubQuery";
 import { PullRequestContributionsByRepository } from "@/types/github";
 import { useMemo } from "react";
 
-export const useGitHubPullRequests = (year: number) => {
+export const useGitHubPullRequests = (year: number, login: string) => {
   const params = useMemo(() => {
     return {
       from: `${year}-01-01T00:00:00`,
+      login,
     };
-  }, [year]);
+  }, [year, login]);
 
   const { data, isLoading } = useGitHubQuery(pullRequests, params);
 

--- a/src/hooks/useGitHubQuery.ts
+++ b/src/hooks/useGitHubQuery.ts
@@ -16,10 +16,7 @@ export const useGitHubQuery = (
       auth: session.accessToken,
     });
 
-    return await gh.graphql<GraphQlQueryResponseData>(query, {
-      login: session.user.login,
-      ...parameters,
-    });
+    return await gh.graphql<GraphQlQueryResponseData>(query, parameters);
   };
 
   const queryResult = useQuery({

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -4,6 +4,9 @@ import GithubProvider from "next-auth/providers/github";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { Octokit } from "octokit";
 
+export const MAIN_LOGIN_PROVIDER =
+  process.env.NODE_ENV === "development" ? undefined : "github";
+
 export default NextAuth({
   providers: [
     GithubProvider({

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -55,24 +55,20 @@ export default NextAuth({
   ],
   callbacks: {
     jwt({ token, user, account }) {
-      // Coming from GithubProvider
+      if (account?.type === "credentials" && user) {
+        const { accessToken, ...rest } = user as any;
+
+        return {
+          accessToken,
+          user: rest,
+        };
+      }
+
       if (account && user) {
         return {
           accessToken: account.access_token,
           refreshToken: account.refresh_token,
           user,
-        };
-      }
-
-      // Coming from CredentialsProvider only used in dev mode
-      if (token) {
-        const {
-          user: { accessToken, ...user },
-        } = token as any;
-
-        return {
-          accessToken,
-          user: user,
         };
       }
 

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,8 @@
 import { GitHubUser } from "@/types/session";
 import NextAuth from "next-auth";
 import GithubProvider from "next-auth/providers/github";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { Octokit } from "octokit";
 
 export default NextAuth({
   providers: [
@@ -16,14 +18,61 @@ export default NextAuth({
         } as GitHubUser;
       },
     }),
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {},
+      async authorize() {
+        if (!process.env.DEV_GITHUB_TOKEN)
+          throw new Error("No DEV_GITHUB_TOKEN env variable set");
+
+        if (process.env.NODE_ENV !== "development")
+          throw new Error("CredentialsProvider can only be used in dev mode");
+
+        const gh = new Octokit({
+          auth: process.env.DEV_GITHUB_TOKEN,
+        });
+
+        const { viewer } = await gh.graphql<{ viewer: any }>(`
+          {
+            viewer {
+              id
+              name
+              login
+              avatarUrl
+            }
+          }
+          `);
+
+        return {
+          id: viewer.id,
+          name: viewer.name,
+          login: viewer.login,
+          image: viewer.avatarUrl,
+          accessToken: process.env.DEV_GITHUB_TOKEN,
+        } as GitHubUser & { accessToken: string };
+      },
+    }),
   ],
   callbacks: {
     jwt({ token, user, account }) {
+      // Coming from GithubProvider
       if (account && user) {
         return {
           accessToken: account.access_token,
           refreshToken: account.refresh_token,
           user,
+        };
+      }
+
+      // Coming from CredentialsProvider only used in dev mode
+      if (token) {
+        const {
+          user: { accessToken, ...user },
+        } = token as any;
+
+        return {
+          accessToken,
+          user: user,
         };
       }
 
@@ -34,7 +83,6 @@ export default NextAuth({
         ...session,
         user: token.user,
         accessToken: token.accessToken,
-        mario: 1,
       };
     },
   },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { signIn, useSession } from "next-auth/react";
 import Link from "next/link";
 
 export default function Home() {
-  const { status } = useSession();
+  const { data: session, status } = useSession();
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-12 p-16">
@@ -13,11 +13,11 @@ export default function Home() {
         Show your efforts to your friends (and in your CV)
       </p>
       {status === "authenticated" ? (
-        <Link href={"/stats"} className="btn btn-primary">
+        <Link href={`/stats/${session.user.login}`} className="btn btn-primary">
           Get Started
         </Link>
       ) : (
-        <button onClick={() => signIn("github")} className="btn">
+        <button onClick={() => signIn()} className="btn">
           Sign in
         </button>
       )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { signIn, useSession } from "next-auth/react";
 import Link from "next/link";
+import { MAIN_LOGIN_PROVIDER } from "./api/auth/[...nextauth]";
 
 export default function Home() {
   const { data: session, status } = useSession();
@@ -17,7 +18,7 @@ export default function Home() {
           Get Started
         </Link>
       ) : (
-        <button onClick={() => signIn()} className="btn">
+        <button onClick={() => signIn(MAIN_LOGIN_PROVIDER)} className="btn">
           Sign in
         </button>
       )}

--- a/src/pages/stats/[login].tsx
+++ b/src/pages/stats/[login].tsx
@@ -1,16 +1,23 @@
 import { RepositoryContributionsCard } from "@/components";
 import { useGitHubPullRequests } from "@/hooks";
 import { useSession } from "next-auth/react";
+import { useRouter } from "next/router";
 import { useState } from "react";
 
 const yearsRange = 4;
 
 export default function Stats() {
   const { data: session } = useSession();
+  const router = useRouter();
+  const { login } = router.query;
+
   const baseYear = new Date().getFullYear();
   const [year, setYear] = useState<number>(baseYear);
   const [format, setFormat] = useState<"cards" | "text" | "json">("cards");
-  const { repositories, isLoading } = useGitHubPullRequests(year);
+  const { repositories, isLoading } = useGitHubPullRequests(
+    year,
+    login as string
+  );
 
   return (
     <div className="h-full w-full px-4 flex flex-col gap-4">


### PR DESCRIPTION
This PR fixes #6 

Looks like we need to be logged in to use the GraphQL endpoints, so no guest mode for now.

I have added a new login mode with credentials that basically reads from `env.DEV_GITHUB_TOKEN` and fakes a login with it, making work on local as easy as generating a GitHub token.