### PR TITLE
feat: :zap: export stats as image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/react-dom": "18.2.7",
         "autoprefixer": "10.4.14",
         "eslint-config-next": "13.4.12",
+        "html-to-image": "^1.11.11",
         "next": "13.4.12",
         "next-auth": "^4.22.3",
         "octokit": "^3.0.0",
@@ -4247,6 +4248,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -10747,6 +10753,11 @@
       "requires": {
         "whatwg-encoding": "^2.0.0"
       }
+    },
+    "html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "http-proxy-agent": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "18.2.7",
     "autoprefixer": "10.4.14",
     "eslint-config-next": "13.4.12",
+    "html-to-image": "^1.11.11",
     "next": "13.4.12",
     "next-auth": "^4.22.3",
     "octokit": "^3.0.0",

--- a/src/pages/stats/[login].tsx
+++ b/src/pages/stats/[login].tsx
@@ -3,6 +3,7 @@ import { useGitHubPullRequests } from "@/hooks";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
+import { exportStats } from "@/utils";
 
 const yearsRange = 4;
 
@@ -10,7 +11,6 @@ export default function Stats() {
   const { data: session } = useSession();
   const router = useRouter();
   const { login } = router.query;
-
   const baseYear = new Date().getFullYear();
   const [year, setYear] = useState<number>(baseYear);
   const [format, setFormat] = useState<"cards" | "text" | "json">("cards");
@@ -155,6 +155,34 @@ export default function Stats() {
             })}
           </div>
         </div>
+
+        <div className="dropdown">
+          <label tabIndex={0} className="btn m-1">
+            export as image
+          </label>
+          <ul
+            tabIndex={0}
+            className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52"
+          >
+            <li>
+              <button
+                className="btn btn-ghost"
+                onClick={async () => await exportStats(".grid", "download")}
+              >
+                Download as PNG
+              </button>
+            </li>
+            <li>
+              <button
+                className="btn btn-ghost"
+                onClick={async () => await exportStats(".grid", "clipboard")}
+              >
+                Copy to Clipboard
+              </button>
+            </li>
+          </ul>
+        </div>
+
         <div className="sm:text-right text-center">
           <div>Select Format</div>
           <div className="join">

--- a/src/pages/stats/[login].tsx
+++ b/src/pages/stats/[login].tsx
@@ -96,7 +96,7 @@ export default function Stats() {
               >
                 <li>
                   <button
-                    className="btn btn-ghost"
+                    className="btn-ghost"
                     onClick={async () => await exportStats(".grid", "download")}
                   >
                     Download as PNG
@@ -104,7 +104,7 @@ export default function Stats() {
                 </li>
                 <li>
                   <button
-                    className="btn btn-ghost"
+                    className="btn-ghost"
                     onClick={async () =>
                       await exportStats(".grid", "clipboard")
                     }
@@ -115,9 +115,9 @@ export default function Stats() {
               </ul>
             </div>
             <div className="w-full grid xl:grid-cols-3 gap-3 mb-3 md:grid-cols-2">
-              {repositories?.map(({ repository, contributions }) => (
+              {repositories?.map(({ repository, contributions }, i) => (
                 <RepositoryContributionsCard
-                  key={repository.name}
+                  key={i + repository.name}
                   repository={repository}
                   contributions={contributions}
                 />

--- a/src/pages/stats/[login].tsx
+++ b/src/pages/stats/[login].tsx
@@ -82,15 +82,48 @@ export default function Stats() {
     switch (format) {
       case "cards":
         return (
-          <div className="w-full grid xl:grid-cols-3 gap-3 mb-3 md:grid-cols-2">
-            {repositories?.map(({ repository, contributions }) => (
-              <RepositoryContributionsCard
-                key={repository.name}
-                repository={repository}
-                contributions={contributions}
-              />
-            ))}
-          </div>
+          <>
+            <div className="dropdown">
+              <label
+                tabIndex={0}
+                className="bg-blue-500 p-2 m-1 rounded hover:bg-blue-900"
+              >
+                Export as image
+              </label>
+              <ul
+                tabIndex={0}
+                className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52"
+              >
+                <li>
+                  <button
+                    className="btn btn-ghost"
+                    onClick={async () => await exportStats(".grid", "download")}
+                  >
+                    Download as PNG
+                  </button>
+                </li>
+                <li>
+                  <button
+                    className="btn btn-ghost"
+                    onClick={async () =>
+                      await exportStats(".grid", "clipboard")
+                    }
+                  >
+                    Copy to Clipboard
+                  </button>
+                </li>
+              </ul>
+            </div>
+            <div className="w-full grid xl:grid-cols-3 gap-3 mb-3 md:grid-cols-2">
+              {repositories?.map(({ repository, contributions }) => (
+                <RepositoryContributionsCard
+                  key={repository.name}
+                  repository={repository}
+                  contributions={contributions}
+                />
+              ))}
+            </div>
+          </>
         );
       case "json":
         return (
@@ -154,33 +187,6 @@ export default function Stats() {
               );
             })}
           </div>
-        </div>
-
-        <div className="dropdown">
-          <label tabIndex={0} className="btn m-1">
-            export as image
-          </label>
-          <ul
-            tabIndex={0}
-            className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52"
-          >
-            <li>
-              <button
-                className="btn btn-ghost"
-                onClick={async () => await exportStats(".grid", "download")}
-              >
-                Download as PNG
-              </button>
-            </li>
-            <li>
-              <button
-                className="btn btn-ghost"
-                onClick={async () => await exportStats(".grid", "clipboard")}
-              >
-                Copy to Clipboard
-              </button>
-            </li>
-          </ul>
         </div>
 
         <div className="sm:text-right text-center">

--- a/src/utils/exportStats.ts
+++ b/src/utils/exportStats.ts
@@ -1,0 +1,33 @@
+import { toPng } from "html-to-image";
+
+export const exportStats = async (
+  selector: string,
+  option: "download" | "clipboard"
+) => {
+  const dataURI = await toPng(document.querySelector(selector) as HTMLElement);
+  const image = new Image();
+  image.src = dataURI;
+  image.onload = () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const context = canvas.getContext("2d");
+    context?.drawImage(image, 0, 0);
+    canvas.toBlob((blob) => {
+      if (blob) {
+        if (option === "download") {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = "stats.png";
+          a.click();
+          URL.revokeObjectURL(url);
+          a.remove();
+        }
+        if (option === "clipboard")
+          navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+      }
+    });
+    canvas.remove();
+  };
+};

--- a/src/utils/exportStats.ts
+++ b/src/utils/exportStats.ts
@@ -4,7 +4,10 @@ export const exportStats = async (
   selector: string,
   option: "download" | "clipboard"
 ) => {
-  const dataURI = await toPng(document.querySelector(selector) as HTMLElement);
+  const dataURI = await toPng(document.querySelector(".grid") as HTMLElement, {
+    includeQueryParams: true,
+    cacheBust: true,
+  });
   const image = new Image();
   image.src = dataURI;
   image.onload = () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./exportStats";


### PR DESCRIPTION
Resolve #4 
This pull request introduces a feature that enhances the usability of the application by allowing users to export stats in two different formats. The addition includes a new button with two distinct options for exporting the stats: downloading an image representation of the statistics and copying the image to the clipboard.
