### PR TITLE
feat: :heavy_plus_sign: Add total received stars

### DIFF
--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -38,10 +38,14 @@ query ($login: String!) {
         name
         followers {
             totalCount
+        } 
+       starsCount: repositories(first: 0, isFork: false) {
+        totalCount
         }
-    }
+     }
 }
 `;
+
 export type UserProfile = {
   user: User;
 };

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -30,6 +30,9 @@ export default function Profile() {
             <p className="text-sm text-gray-400">
               Followers: {data.user.followers.totalCount}
             </p>
+            <p className="text-sm text-gray-400">
+              Stars Count: {data.user.starsCount.totalCount}
+            </p>
           </div>
 
           <p>{data.user.bio}</p>

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -37,4 +37,7 @@ export type User = {
   followers: {
     totalCount: number;
   };
+  starsCount: {
+    totalCount: number;
+  };
 };


### PR DESCRIPTION
Resolve #17

This pull request addresses issue #17 by enhancing the user profile page to display the total number of stars a user has received on their repositories. The star count excludes forked repositories, providing a more accurate representation of the user's contributions and achievements.

To achieve this, the GraphQL query `userProfileQuery` has been updated to filter out forked repositories using the `isFork` field in the `repositories` connection. This ensures that only the stars given to the user's own repositories are counted in the displayed star count.

Here's a snippet of the updated code:

```javascript
export const userProfileQuery = `
query ($login: String!) {
    user(login: $login) {
        login
        avatarUrl
        bio
        name
        followers {
            totalCount
        } 
        starsCount: repositories(first: 0, isFork: false) {
            totalCount
        }
    }
}
`;
```

![image](https://github.com/Balastrong/github-stats/assets/75867744/c0887345-8dc3-4342-86a3-325702c17b88)
