### PR TITLE
feat: :heavy_plus_sign: Adding export as image in profile page

### DIFF
--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -5,6 +5,7 @@ import {
 import { useGitHubQuery } from "@/hooks";
 import Image from "next/image";
 import Link from "next/link";
+import { exportAsImage } from "@/utils";
 
 export default function Profile() {
   const { data } = useGitHubQuery<UserProfile>(userProfileQuery);
@@ -12,38 +13,81 @@ export default function Profile() {
   if (!data) return "Loading...";
 
   return (
-    <div className="card w-96 mx-auto my-10 bg-base-100 shadow-xl h-100 relative">
-      <div className="absolute h-[100px] bg-base-200 top-0 w-full rounded-t-2xl"></div>
-      <div className="z-10">
-        <figure className="px-10 pt-10">
-          <Image
-            src={data.user.avatarUrl}
-            alt={data?.user.login}
-            width={120}
-            height={120}
-            className="rounded-full"
-          />
-        </figure>
-        <div className="card-body items-center text-center gap-4">
-          <div>
-            <h2 className="card-title">{data.user.name}</h2>
-            <p className="text-sm text-gray-400">
-              Followers: {data.user.followers.totalCount}
-            </p>
-            <p className="text-sm text-gray-400">
-              Stars Count: {data.user.starsCount.totalCount}
-            </p>
-          </div>
+    <div>
+      <div className="flex justify-center">
+        <div className="dropdown pt-10 ">
+          <label
+            tabIndex={0}
+            className="bg-blue-500 p-2 m-1 rounded hover:bg-blue-900 "
+          >
+            Export as image
+          </label>
+          <ul
+            tabIndex={0}
+            className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 z-20"
+          >
+            <li>
+              <button
+                className="btn-ghost"
+                onClick={async () =>
+                  await exportAsImage(
+                    "#profile-card",
+                    "download",
+                    "profile-card"
+                  )
+                }
+              >
+                Download as PNG
+              </button>
+            </li>
+            <li>
+              <button
+                className="btn-ghost"
+                onClick={async () =>
+                  await exportAsImage("#profile-card", "clipboard")
+                }
+              >
+                Copy to Clipboard
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div id="profile-card" className="p-1">
+        <div className="card w-96 mx-auto my-10 bg-base-100 shadow-xl h-100 relative">
+          <div className="absolute h-[100px] bg-base-200 top-0 w-full rounded-t-2xl"></div>
+          <div className="z-10">
+            <figure className="px-10 pt-10">
+              <Image
+                src={data.user.avatarUrl}
+                alt={data?.user.login}
+                width={120}
+                height={120}
+                className="rounded-full"
+              />
+            </figure>
+            <div className="card-body items-center text-center gap-4">
+              <div>
+                <h2 className="card-title">{data.user.name}</h2>
+                <p className="text-sm text-gray-400">
+                  Followers: {data.user.followers.totalCount}
+                </p>
+                <p className="text-sm text-gray-400">
+                  Stars Count: {data.user.starsCount.totalCount}
+                </p>
+              </div>
 
-          <p>{data.user.bio}</p>
-          <div className="card-actions mt-1">
-            <Link
-              className="btn btn-primary"
-              href={`https://github.com/${data.user.login}`}
-              target="_blank"
-            >
-              GitHub
-            </Link>
+              <p>{data.user.bio}</p>
+              <div className="card-actions mt-1">
+                <Link
+                  className="btn btn-primary"
+                  href={`https://github.com/${data.user.login}`}
+                  target="_blank"
+                >
+                  GitHub
+                </Link>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -29,12 +29,8 @@ export default function Profile() {
             <li>
               <button
                 className="btn-ghost"
-                onClick={async () =>
-                  await exportAsImage(
-                    "#profile-card",
-                    "download",
-                    "profile-card"
-                  )
+                onClick={() =>
+                  exportAsImage("#profile-card", "download", "profile-card")
                 }
               >
                 Download as PNG
@@ -43,9 +39,7 @@ export default function Profile() {
             <li>
               <button
                 className="btn-ghost"
-                onClick={async () =>
-                  await exportAsImage("#profile-card", "clipboard")
-                }
+                onClick={() => exportAsImage("#profile-card", "clipboard")}
               >
                 Copy to Clipboard
               </button>
@@ -53,17 +47,17 @@ export default function Profile() {
           </ul>
         </div>
       </div>
-      <div id="profile-card" className="p-1">
-        <div className="card w-96 mx-auto my-10 bg-base-100 shadow-xl h-100 relative">
-          <div className="absolute h-[100px] bg-base-200 top-0 w-full rounded-t-2xl"></div>
-          <div className="z-10">
+      <div>
+        <div className="card w-96 mx-auto my-10 bg-base-100 shadow-xl h-100  ">
+          <div id="profile-card" className="relative bg-base-100 rounded-2xl ">
+            <div className="absolute h-[100px] bg-base-200 w-full rounded-t-2xl" />
             <figure className="px-10 pt-10">
               <Image
                 src={data.user.avatarUrl}
                 alt={data?.user.login}
                 width={120}
                 height={120}
-                className="rounded-full"
+                className="rounded-full z-10"
               />
             </figure>
             <div className="card-body items-center text-center gap-4">

--- a/src/pages/stats/[login].tsx
+++ b/src/pages/stats/[login].tsx
@@ -97,9 +97,7 @@ export default function Stats() {
                 <li>
                   <button
                     className="btn-ghost"
-                    onClick={async () =>
-                      await exportAsImage(".grid", "download", "stats")
-                    }
+                    onClick={() => exportAsImage(".grid", "download", "stats")}
                   >
                     Download as PNG
                   </button>
@@ -107,9 +105,7 @@ export default function Stats() {
                 <li>
                   <button
                     className="btn-ghost"
-                    onClick={async () =>
-                      await exportAsImage(".grid", "clipboard")
-                    }
+                    onClick={() => exportAsImage(".grid", "clipboard")}
                   >
                     Copy to Clipboard
                   </button>

--- a/src/pages/stats/[login].tsx
+++ b/src/pages/stats/[login].tsx
@@ -3,7 +3,7 @@ import { useGitHubPullRequests } from "@/hooks";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
-import { exportStats } from "@/utils";
+import { exportAsImage } from "@/utils";
 
 const yearsRange = 4;
 
@@ -97,7 +97,9 @@ export default function Stats() {
                 <li>
                   <button
                     className="btn-ghost"
-                    onClick={async () => await exportStats(".grid", "download")}
+                    onClick={async () =>
+                      await exportAsImage(".grid", "download", "stats")
+                    }
                   >
                     Download as PNG
                   </button>
@@ -106,7 +108,7 @@ export default function Stats() {
                   <button
                     className="btn-ghost"
                     onClick={async () =>
-                      await exportStats(".grid", "clipboard")
+                      await exportAsImage(".grid", "clipboard")
                     }
                   >
                     Copy to Clipboard

--- a/src/pages/stats/[login].tsx
+++ b/src/pages/stats/[login].tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 import { exportAsImage } from "@/utils";
+import { PullRequestContributionsByRepository } from "@/types/github";
 
 const yearsRange = 4;
 
@@ -14,10 +15,13 @@ export default function Stats() {
   const baseYear = new Date().getFullYear();
   const [year, setYear] = useState<number>(baseYear);
   const [format, setFormat] = useState<"cards" | "text" | "json">("cards");
-  const { repositories, isLoading } = useGitHubPullRequests(
-    year,
-    login as string
-  );
+  const {
+    repositories,
+    isLoading,
+  }: {
+    repositories: PullRequestContributionsByRepository[];
+    isLoading: boolean;
+  } = useGitHubPullRequests(year, login as string);
 
   const exportJSON = () => {
     const jsonStringData = JSON.stringify(repositories, null, 2);
@@ -137,15 +141,15 @@ export default function Stats() {
         );
       case "text":
         return (
-          <pre>
+          <div>
             <button
               className="bg-blue-500 p-2 m-1 rounded hover:bg-blue-900"
               onClick={exportText}
             >
               Export as Text
             </button>
-            {generateText()}
-          </pre>
+            <pre>{generateText()}</pre>
+          </div>
         );
       default:
         return (

--- a/src/utils/exportAsImage.ts
+++ b/src/utils/exportAsImage.ts
@@ -1,10 +1,11 @@
 import { toPng } from "html-to-image";
 
-export const exportStats = async (
+export const exportAsImage = async (
   selector: string,
-  option: "download" | "clipboard"
+  option: "download" | "clipboard",
+  filename?: string
 ) => {
-  const dataURI = await toPng(document.querySelector(".grid") as HTMLElement, {
+  const dataURI = await toPng(document.querySelector(selector) as HTMLElement, {
     includeQueryParams: true,
     cacheBust: true,
   });
@@ -22,7 +23,7 @@ export const exportStats = async (
           const url = URL.createObjectURL(blob);
           const a = document.createElement("a");
           a.href = url;
-          a.download = "stats.png";
+          a.download = `${filename}.png`;
           a.click();
           URL.revokeObjectURL(url);
           a.remove();

--- a/src/utils/exportAsImage.ts
+++ b/src/utils/exportAsImage.ts
@@ -23,7 +23,7 @@ export const exportAsImage = async (
           const url = URL.createObjectURL(blob);
           const a = document.createElement("a");
           a.href = url;
-          a.download = `${filename}.png`;
+          a.download = filename ? `${filename}.png` : "image.png";
           a.click();
           URL.revokeObjectURL(url);
           a.remove();

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export * from "./exportStats";
+export * from "./exportAsImage";


### PR DESCRIPTION
Resolve #39 

This pull request introduces a feature to the /profile page – the addition of a sleek export button. This button empowers users to export an Image of the card of their profile.

![image](https://github.com/Balastrong/github-stats/assets/75867744/da1ff0f6-6191-4e15-b573-a2d9ba9fd39f)
