### PR TITLE
fix: Make Background Size Flexible

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -28,5 +28,5 @@ body {
 
 body,
 html {
-  height: 100%;
+  min-height: 100vh;
 }


### PR DESCRIPTION
This PR Resolves #42, It makes the size of the background flexible to the content and sets it minimum to 100vh to avoid the multi-background color issue.

**Before** (At Bottom)

![262354845-cd97c8ae-4ee4-4cb1-b3bf-cb54527494fa](https://github.com/Balastrong/github-stats/assets/91460022/295de5a9-481e-420f-b75b-9230001014f6)

**After**

![temp](https://github.com/Balastrong/github-stats/assets/91460022/ee2c68a9-01b5-4eac-ba24-948f850fac9a)
