### PR TITLE
fix: theme loading issue

### DIFF
--- a/cypress/e2e/darkmode.spec.cy.ts
+++ b/cypress/e2e/darkmode.spec.cy.ts
@@ -2,7 +2,7 @@ describe("DarkMode test", () => {
   beforeEach(() => {
     cy.visit("http://localhost:3000");
     cy.wait(3000);
-    cy.get('[data-testid="darkModeButton"]').click();
+    cy.get('[data-testid="themeSelectorButton"]').click();
   });
 
   it("should select light Mode", () => {
@@ -27,7 +27,7 @@ describe("DarkMode test", () => {
       },
     });
     cy.wait(3000);
-    cy.get('[data-testid="darkModeButton"]').click();
+    cy.get('[data-testid="themeSelectorButton"]').click();
     cy.get('[data-testid="system-mode-option"]').click();
     cy.get("html").should("have.data", "theme", "custom-dark");
   });

--- a/src/components/DarkModeDropdown.tsx
+++ b/src/components/DarkModeDropdown.tsx
@@ -1,22 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 type DarkModeOptions = "custom-dark" | "light" | "system";
 
 export function DarkModeDropdown() {
   const [darkModeOption, setDarkModeOption] =
     useState<DarkModeOptions>("light");
-
-  useEffect(() => {
-    if (
-      localStorage.theme === "light" ||
-      (!("theme" in localStorage) &&
-        !window.matchMedia("(prefers-color-scheme:dark)").matches)
-    ) {
-      setDocumentElement("light");
-    } else {
-      setDocumentElement("custom-dark");
-    }
-  }, []);
 
   function onClick($event: React.MouseEvent<HTMLLIElement>) {
     $event.stopPropagation();

--- a/src/components/DarkModeDropdown.tsx
+++ b/src/components/DarkModeDropdown.tsx
@@ -1,10 +1,18 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type DarkModeOptions = "custom-dark" | "light" | "system";
 
 export function DarkModeDropdown() {
-  const [darkModeOption, setDarkModeOption] =
-    useState<DarkModeOptions>("light");
+  const [darkModeOption, setDarkModeOption] = useState<
+    DarkModeOptions | undefined
+  >(undefined);
+
+  useEffect(() => {
+    const theme = localStorage.getItem("theme") as DarkModeOptions;
+    if (theme) {
+      setDarkModeOption(theme);
+    }
+  }, []);
 
   function onClick($event: React.MouseEvent<HTMLLIElement>) {
     $event.stopPropagation();
@@ -107,17 +115,16 @@ const SystemPreference = () => (
   </svg>
 );
 
-const getButtonIconByOption = (option: DarkModeOptions) => {
+const getButtonIconByOption = (option: DarkModeOptions | undefined) => {
   switch (option) {
-    case "light": {
+    case "light":
       return <LightMode />;
-    }
-    case "custom-dark": {
+
+    case "custom-dark":
       return <DarkMode />;
-    }
-    case "system": {
+
+    default:
       return <SystemPreference />;
-    }
   }
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { MAIN_LOGIN_PROVIDER } from "@/pages/api/auth/[...nextauth]";
 import { signIn, signOut, useSession } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
-import { DarkModeDropdown } from "./DarkModeDropdown";
+import { ThemeSelector } from "./ThemeSelector";
 
 export const Header = () => {
   const { data: session, status } = useSession();
@@ -60,7 +60,7 @@ export const Header = () => {
             </ul>
           </div>
           <div className="navbar-end">
-            <DarkModeDropdown />
+            <ThemeSelector />
             {status === "authenticated" ? (
               <div className="dropdown dropdown-end">
                 <label tabIndex={0} className="btn btn-ghost btn-circle avatar">

--- a/src/components/ThemeSelector.test.tsx
+++ b/src/components/ThemeSelector.test.tsx
@@ -1,18 +1,18 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, test, expect } from "vitest";
-import { DarkModeDropdown } from "./DarkModeDropdown";
+import { ThemeSelector } from "./ThemeSelector";
 
-describe("DarkModeDropdown", () => {
+describe("ThemeSelector", () => {
   test("should change light Icon if click Dark mode", () => {
-    render(<DarkModeDropdown />);
+    render(<ThemeSelector />);
 
-    const button = screen.getByTestId("darkModeButton");
+    const button = screen.getByTestId("themeSelectorButton");
     fireEvent.click(button);
 
     const darkModeItem = screen.getByTestId("dark-mode-option");
     fireEvent.click(darkModeItem);
 
-    const buttonEdited = screen.getByTestId("darkModeButton");
+    const buttonEdited = screen.getByTestId("themeSelectorButton");
     const darkModeSvg = buttonEdited.firstElementChild as SVGElement;
     const testidValue = darkModeSvg.dataset.testid;
 
@@ -25,14 +25,14 @@ describe("DarkModeDropdown", () => {
   });
 
   test("should change to System Preference", () => {
-    render(<DarkModeDropdown />);
+    render(<ThemeSelector />);
 
-    const button = screen.getByTestId("darkModeButton");
+    const button = screen.getByTestId("themeSelectorButton");
     fireEvent.click(button);
     const systemItem = screen.getByTestId("system-mode-option");
     fireEvent.click(systemItem);
 
-    const buttonEdited = screen.getByTestId("darkModeButton");
+    const buttonEdited = screen.getByTestId("themeSelectorButton");
     const systemSvg = buttonEdited.firstElementChild as SVGAElement;
     const testidValue = systemSvg.dataset.testid;
 

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,33 +1,31 @@
 import { useEffect, useState } from "react";
 
-type DarkModeOptions = "custom-dark" | "light" | "system";
+type ThemeOptions = "custom-dark" | "light" | "system";
 
-export function DarkModeDropdown() {
-  const [darkModeOption, setDarkModeOption] = useState<
-    DarkModeOptions | undefined
-  >(undefined);
+export function ThemeSelector() {
+  const [selectedTheme, setSelectedTheme] = useState<ThemeOptions | undefined>(
+    undefined
+  );
 
   useEffect(() => {
-    const theme = localStorage.getItem("theme") as DarkModeOptions;
+    const theme = localStorage.getItem("theme") as ThemeOptions;
     if (theme) {
-      setDarkModeOption(theme);
+      setSelectedTheme(theme);
     }
   }, []);
 
   function onClick($event: React.MouseEvent<HTMLLIElement>) {
     $event.stopPropagation();
     const li = $event.currentTarget as HTMLLIElement;
-    setDocumentElement(li.id as DarkModeOptions);
+    setDocumentElement(li.id as ThemeOptions);
   }
 
-  const setDocumentElement = (theme: DarkModeOptions) => {
-    setDarkModeOption(theme);
-    theme === "system"
-      ? setSystemPreferenceTheme()
-      : setLightOrDarkTheme(theme);
+  const setDocumentElement = (theme: ThemeOptions) => {
+    setSelectedTheme(theme);
+    theme === "system" ? setSystemPreferenceTheme() : setTheme(theme);
   };
 
-  const buttonIcon = getButtonIconByOption(darkModeOption);
+  const buttonIcon = getButtonIconByOption(selectedTheme);
 
   return (
     <>
@@ -35,7 +33,7 @@ export function DarkModeDropdown() {
         <label
           tabIndex={0}
           className="btn btn-circle btn-ghost m-1"
-          data-testid="darkModeButton"
+          data-testid="themeSelectorButton"
         >
           {buttonIcon}
         </label>
@@ -115,7 +113,7 @@ const SystemPreference = () => (
   </svg>
 );
 
-const getButtonIconByOption = (option: DarkModeOptions | undefined) => {
+const getButtonIconByOption = (option: ThemeOptions | undefined) => {
   switch (option) {
     case "light":
       return <LightMode />;
@@ -130,14 +128,11 @@ const getButtonIconByOption = (option: DarkModeOptions | undefined) => {
 
 const setSystemPreferenceTheme = () => {
   const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  setTheme(isDark ? "custom-dark" : "light");
   localStorage.removeItem("theme");
-  document.documentElement.dataset.theme = isDark ? "custom-dark" : "light";
-  isDark
-    ? document.documentElement.classList.add("dark")
-    : document.documentElement.classList.remove("dark");
 };
 
-const setLightOrDarkTheme = (theme: "custom-dark" | "light") => {
+const setTheme = (theme: "custom-dark" | "light") => {
   localStorage.theme = theme;
   document.documentElement.dataset.theme = theme;
   theme === "custom-dark"

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,6 +5,19 @@ export default function Document() {
     <Html lang="en" data-theme="light">
       <Head />
       <body className="light-mode dark:dark-mode">
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                var theme = localStorage.getItem('theme');
+                document.documentElement.dataset.theme = theme;
+                theme === "custom-dark"
+                  ? document.documentElement.classList.add("dark")
+                  : document.documentElement.classList.remove("dark");
+              })()
+            `,
+          }}
+        />
         <Main />
         <NextScript />
       </body>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -10,10 +10,13 @@ export default function Document() {
             __html: `
               (function() {
                 var theme = localStorage.getItem('theme');
-                document.documentElement.dataset.theme = theme;
-                theme === "custom-dark"
-                  ? document.documentElement.classList.add("dark")
-                  : document.documentElement.classList.remove("dark");
+                if (theme === "custom-dark" || (!theme && window.matchMedia("(prefers-color-scheme:dark)").matches)) {
+                  document.documentElement.dataset.theme = "custom-dark";
+                  document.documentElement.classList.add("dark")
+                } else {
+                  document.documentElement.dataset.theme = "light";
+                  document.documentElement.classList.remove("dark");
+                }
               })()
             `,
           }}


### PR DESCRIPTION
This pull request fixes an issue with the theme loading in the DarkModeDropdown component. Previously, the useEffect hook was used to set the document element based on the localStorage theme. However, this caused a flickering issue when the theme was changed. This PR removes the useEffect hook and instead sets the theme directly in the script tag in the Document component. This ensures that the theme is loaded earlier and avoids the flickering issue.

^ generated with copilot